### PR TITLE
Update values.yaml

### DIFF
--- a/uptime-dashboard/values.yaml
+++ b/uptime-dashboard/values.yaml
@@ -12,7 +12,7 @@ users:
 grafana:
   image:
     repository: registry.puzzle.ch/docker.io/grafana
-    tag: 8.3.1
+    tag: 8.5.9
   rbac:
     create: true
     pspEnabled: false


### PR DESCRIPTION
the image was not available anymore and resulted in an ImagePullError. I configured this to the latest 8.x image in the registry. There is also a 9.x tag available, but haven't tested and not sure how big the changes are.