### PR TITLE
Fix incorrect relabel target

### DIFF
--- a/deploy/uptime-dashboard/overlays/prod/prometheus.yml
+++ b/deploy/uptime-dashboard/overlays/prod/prometheus.yml
@@ -21,4 +21,4 @@ scrape_configs:
     - source_labels: [__param_target]
       target_label: instance
     - target_label: __address__
-      replacement: acend-ocp-uptime-monitoring-prometheus-blackbox-exporter:9115
+      replacement: uptime-dashboard-prometheus-blackbox-exporter:9115


### PR DESCRIPTION
The blackbox exporter service has the address `uptime-dashboard-prometheus-blackbox-exporter`:

```bash
$ k -n acend-openshift-operations-monitoring-prod get svc
NAME                                            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
uptime-dashboard-grafana                        ClusterIP   10.43.170.118   <none>        80/TCP     10d
uptime-dashboard-prometheus-blackbox-exporter   ClusterIP   10.43.83.245    <none>        9115/TCP   10d
uptime-dashboard-prometheus-server              ClusterIP   10.43.111.154   <none>        80/TCP     10d
```